### PR TITLE
Automatic continous releases for main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,12 @@
         - uses: actions/checkout@v1
 
         - name: Create a release
-          uses: actions/create-release@v1
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          uses: marvinpinto/action-automatic-releases@v1.2.1
           with:
-            tag_name: 'continuous'
-            release_name: "Continuous Build"
+            repo_token: ${{ secrets.GITHUB_TOKEN }}
+            automatic_release_tag: continuous
             prerelease: true
+            title: "Continuous Build"
 
         - name: Build Go binaries
           uses: wangyoucao577/go-release-action@v1.38

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,14 @@
       runs-on: ubuntu-latest
       steps:
       - name: Create a release
-        uses: marvinpinto/action-automatic-releases@v1.2.1
+        uses: softprops/action-gh-release@v0.1.15
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: continuous
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: continuous
           prerelease: true
-          title: "Continuous Build"
+          name: "Continuous Build"
+          body: |
+            This is a continuous build release.
 
     build:
       runs-on: ubuntu-latest
@@ -48,4 +50,5 @@
             goos: ${{ matrix.goos }}
             goarch: ${{ matrix.goarch }}
             compress_assets: 'OFF'
+            md5sum: 'OFF'
   

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,20 @@
     workflow_dispatch:
 
   jobs:
+    create-release:
+      runs-on: ubuntu-latest
+      steps:
+      - name: Create a release
+        uses: marvinpinto/action-automatic-releases@v1.2.1
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          automatic_release_tag: continuous
+          prerelease: true
+          title: "Continuous Build"
+
     build:
       runs-on: ubuntu-latest
+      needs: create-release
       strategy:
         matrix:
           # build and publish in parallel: linux/amd64, linux/arm64, windows/amd64, darwin/amd64, darwin/arm64
@@ -21,14 +33,6 @@
   
       steps:
         - uses: actions/checkout@v1
-
-        - name: Create a release
-          uses: marvinpinto/action-automatic-releases@v1.2.1
-          with:
-            repo_token: ${{ secrets.GITHUB_TOKEN }}
-            automatic_release_tag: continuous
-            prerelease: true
-            title: "Continuous Build"
 
         - name: Build Go binaries
           uses: wangyoucao577/go-release-action@v1.38

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@
           body: |
             This is a continuous build release.
 
+            It will always contain a build of the latest version of the code in the main branch.
+
     build:
       runs-on: ubuntu-latest
       needs: create-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,8 @@
   on:
     push:
       branches:
-        - master
+        - main
+    workflow_dispatch:
 
   jobs:
     build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@
     create-release:
       runs-on: ubuntu-latest
       steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Update continuous tag to latest commit
         uses: EndBug/latest-tag@latest
         with:
@@ -45,7 +45,7 @@
               goos: windows
   
       steps:
-        - uses: actions/checkout@v1
+        - uses: actions/checkout@v3
 
         - name: Build Go binaries
           uses: wangyoucao577/go-release-action@v1.38

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@
       runs-on: ubuntu-latest
       needs: create-release
       strategy:
+        max-parallel: 1 # Parallel publishing leads to TCP connections being reset by GitHub
         matrix:
           # build and publish in parallel: linux/amd64, linux/arm64, windows/amd64, darwin/amd64, darwin/arm64
           goos: [linux, windows, darwin]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,9 @@
           with:
             github_token: ${{ secrets.GITHUB_TOKEN }}
             release_tag: "continuous"
+            binary_name: "mastodonctl" # Binary file
+            asset_name: "mastodonctl-${{ matrix.goos }}-${{ matrix.goarch }}" # File of asset in release
             goversion: "1.19" # Go version being used in go.mod
-            binary_name: "mastodonctl"
             ldflags: "-s -w" # Strip debug symbols etc. (make binaries smaller)
             goos: ${{ matrix.goos }}
             goarch: ${{ matrix.goarch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,15 @@
       steps:
         - uses: actions/checkout@v1
 
+        - name: Create a release
+          uses: actions/create-release@v1
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            tag_name: 'continuous'
+            release_name: "Continuous Build"
+            prerelease: true
+
         - name: Build Go binaries
           uses: wangyoucao577/go-release-action@v1.38
           with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@
       runs-on: ubuntu-latest
       needs: create-release
       strategy:
-        max-parallel: 1 # Parallel publishing leads to TCP connections being reset by GitHub
+        max-parallel: 6 # Be aware that parallel publishing leads to TCP connections being reset by GitHub
         matrix:
           # build and publish in parallel: linux/amd64, linux/arm64, windows/amd64, darwin/amd64, darwin/arm64
           goos: [linux, windows, darwin]
@@ -62,4 +62,5 @@
             overwrite: 'TRUE' # Overwrites the existing file if it exists
             compress_assets: 'OFF' # Do not put in .zip/.tar.gz
             md5sum: 'OFF' # Do not add bloaty .md5 files
+            retry: 20 # Try to upload the binary 20 times, instead of only 3
   

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@
     create-release:
       runs-on: ubuntu-latest
       steps:
+      - uses: actions/checkout@v1
       - name: Update continuous tag to latest commit
         uses: EndBug/latest-tag@latest
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@
 
   jobs:
     create-release:
+      permissions: write-all
       runs-on: ubuntu-latest
       steps:
       - name: Create a release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,11 @@
     create-release:
       runs-on: ubuntu-latest
       steps:
+      - name: Update continuous tag to latest commit
+        uses: EndBug/latest-tag@latest
+        with:
+          ref: continuous
+      
       - name: Create a release
         uses: softprops/action-gh-release@v0.1.15
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@
     workflow_dispatch:
 
   permissions:
-    contents: write
+    contents: write # for creating release + uploading binaries
 
   jobs:
     create-release:
@@ -44,11 +44,12 @@
           with:
             github_token: ${{ secrets.GITHUB_TOKEN }}
             release_tag: "continuous"
-            goversion: "1.19"
+            goversion: "1.19" # Go version being used in go.mod
             binary_name: "mastodonctl"
-            ldflags: "-s -w"
+            ldflags: "-s -w" # Strip debug symbols etc. (make binaries smaller)
             goos: ${{ matrix.goos }}
             goarch: ${{ matrix.goarch }}
-            compress_assets: 'OFF'
-            md5sum: 'OFF'
+            overwrite: 'TRUE' # Overwrites the existing file if it exists
+            compress_assets: 'OFF' # Do not put in .zip/.tar.gz
+            md5sum: 'OFF' # Do not add bloaty .md5 files
   

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+
+  name: Build mastodonctl
+
+  on:
+    push:
+      branches:
+        - master
+
+  jobs:
+    build:
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          # build and publish in parallel: linux/amd64, linux/arm64, windows/amd64, darwin/amd64, darwin/arm64
+          goos: [linux, windows, darwin]
+          goarch: [amd64, arm64]
+          exclude:
+            - goarch: arm64
+              goos: windows
+  
+      steps:
+        - uses: actions/checkout@v1
+
+        - name: Build Go binaries
+          uses: wangyoucao577/go-release-action@v1.38
+          with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            release_tag: "continuous"
+            goversion: "1.19"
+            binary_name: "mastodonctl"
+            ldflags: "-s -w"
+            goos: ${{ matrix.goos }}
+            goarch: ${{ matrix.goarch }}
+            compress_assets: 'OFF'
+  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,11 @@
         - main
     workflow_dispatch:
 
+  permissions:
+    contents: write
+
   jobs:
     create-release:
-      permissions: write-all
       runs-on: ubuntu-latest
       steps:
       - name: Create a release


### PR DESCRIPTION
This GitHub Actions workflow automatically builds and publishes said builds for the latest main commit.

To do so, it tags the latest commit with `continuous` and uses a pre-release on that tag to upload the assets.
If the release already exists, it keeps the date, but will delete and replace the old assets.