### PR TITLE
remove hashtag cmd flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,22 @@ This is possible by editing [`conf.json`](conf.json) file
 
 ## current available commands
 
+### hashtag
+
+query Mastodon server's API for a specific hashtag
+
+```bash
+mastodonctl hashtag duck
+```
+
 ### userinfos
 
 \* requires auth token for the server used
 
-Will query Mastadon server's API for user infos based on their `username`
+Will query Mastodon server's API for user infos based on their `username`
 
 
-### suggested way to store private credentials
+## suggested way to store private credentials
 
 populate `AuthToken` field in [conf.json](conf.json) configuration file
 

--- a/main.go
+++ b/main.go
@@ -123,18 +123,10 @@ func main() {
 				return nil
 			},
 		}, {
-			Name:      "hashtag",
-			ShortName: "tag",
-			Usage:     "Will get latest post informations about a specific hashtag",
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  "name",
-					Usage: "Keyword (hashtag) word to search for - without # sign!",
-					Value: "cat",
-				},
-			},
+			Name:  "hashtag",
+			Usage: "Will get latest post informations about a specific hashtag - append searched word after the command",
 			Action: func(c *cli.Context) error {
-				hashtag := c.String("name")
+				hashtag := c.Args().Get(0)
 
 				if len(hashtag) <= 0 {
 					fmt.Println("Error: must provide a hashtag value to look for!")


### PR DESCRIPTION
- just have user input searched value after the command. no need to use a `--name` flag for this
- document `hashtag` command with an example